### PR TITLE
fix(ci): remove artifacthub input from test action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,6 @@ jobs:
   test:
     name: run tests and linters
     uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-go-wasi.yml@061457443f381a6c92489003d1d89c67ac32ad51 # v4.3.0
-    with:
-      artifacthub: false
 
   release:
     needs: test


### PR DESCRIPTION
## Description

The input `artifacthub: true` was mistakenly added to the test action, resulting in the failure of the release workflow.